### PR TITLE
Build system fixes and improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,17 +10,8 @@ all: cruft ruleset
 tests: test_plocate test_explain test_filters test_excludes test_dpkg test_dpkg_lib test_python cruftold
 
 cruft.o: cruft.cc explain.h filters.h mlocate.h dpkg.h python.h
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) -c cruft.cc
-
-%.o: %.cc %.h
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) -c $<
-
 dpkg_lib.o: dpkg_lib.cc dpkg.h
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) -c dpkg_lib.cc
-
 dpkg_popen.o: dpkg_popen.cc dpkg.h
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) -c dpkg_popen.cc
-
 shellexp.o: shellexp.c
 
 cruftold: $(SHARED_OBJS) dpkg_popen.o
@@ -30,21 +21,13 @@ cruft: $(SHARED_OBJS) dpkg_lib.o
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) $(SHARED_OBJS) dpkg_lib.o $(LIBDPKG_LIBS) -o cruft
 
 test_%: %.o test_%.cc dpkg_popen.o usr_merge.o
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) $< $@.cc dpkg_popen.o usr_merge.o -o $@
 test_dpkg: test_dpkg.cc dpkg_popen.o usr_merge.o
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) dpkg_popen.o test_dpkg.cc usr_merge.o -o $@
-test_dpkg_lib: test_dpkg.cc dpkg_lib.o
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) dpkg_lib.o test_dpkg.cc usr_merge.o $(LIBDPKG_LIBS) -o $@
+test_dpkg_lib: test_dpkg.cc dpkg_lib.o LDLIBS=$(LIBDPKG_LIBS)
 test_mlocate: mlocate.o test_mlocate.cc
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) mlocate.o test_mlocate.cc -o $@
 test_plocate: plocate.o python.o test_plocate.cc
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) plocate.o python.o test_plocate.cc -o $@
 test_python: python.o test_python.cc
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) python.o test_python.cc -o $@
 test_excludes: dpkg_exclude.o test_excludes.cc
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) dpkg_exclude.o test_excludes.cc -o $@
 test_diversions: test_diversions.cc dpkg_popen.o usr_merge.o
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) test_diversions.cc dpkg_popen.o usr_merge.o -o $@
 
 install: all
 	#install -D -m 2755 -g mlocate cruftg   $(DESTDIR)/usr/bin/cruft

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ dpkg_popen.o: dpkg_popen.cc dpkg.h
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) -c dpkg_popen.cc
 
 shellexp.o: shellexp.c
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) -c shellexp.c
 
 cruftold: $(SHARED_OBJS) dpkg_popen.o
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) $(SHARED_OBJS) dpkg_popen.o -o cruftold

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ cruft.o: cruft.cc explain.h filters.h mlocate.h dpkg.h python.h
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) -c $<
 
 dpkg_lib.o: dpkg_lib.cc dpkg.h
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) -c dpkg_lib.cc -ldpkg
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) -c dpkg_lib.cc
 
 dpkg_popen.o: dpkg_popen.cc dpkg.h
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(CPPFLAGS) -c dpkg_popen.cc

--- a/cruft.cc
+++ b/cruft.cc
@@ -15,7 +15,7 @@
 #include "dpkg.h"
 #include "dpkg_exclude.h"
 
-extern int shellexp(char* filename, char* pattern );
+extern "C" int shellexp(char* filename, char* pattern );
 
 using namespace std;
 

--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Alexandre Detiste <alexandre.detiste@gmail.com>
 Build-Depends:
+    pkg-config,
     libdpkg-dev,
     debhelper-compat (= 13),
 Standards-Version: 4.6.1.0

--- a/shellexp.c
+++ b/shellexp.c
@@ -1,7 +1,5 @@
 #include <stdio.h>
-
-#define FALSE false
-#define TRUE  true
+#include <stdbool.h>
 
 /* 0 on no match, non-zero on match */
 int shellexp( char* string, char* pattern ) {
@@ -14,7 +12,7 @@ int shellexp( char* string, char* pattern ) {
 	switch( string[0] ) {
 	case '\0':
 	case '/':
-	    return FALSE;
+	    return false;
 	default:
 	    return shellexp( string+1, pattern+1 );
 	}
@@ -25,52 +23,52 @@ int shellexp( char* string, char* pattern ) {
 		fprintf( stderr, "Bad expression.\n" );
 		return -1;
 	    }
-	    if ( *pch != '/' ) return FALSE;
-	    if ( pattern[3] == '\0' ) return TRUE;
+	    if ( *pch != '/' ) return false;
+	    if ( pattern[3] == '\0' ) return true;
 	    while ( *pch != '\0' ) {
 		if ( *pch == '/' ) {
 		    int ret = shellexp( pch, pattern + 3 );
-		    if ( ret == TRUE || ret == -1 )
+		    if ( ret == true || ret == -1 )
 		    	return ret;
 		}
 		pch++;
 	    }
-	    return FALSE;
+	    return false;
 	} else if ( string[0] == '/' ) {
 		return shellexp( string+1, pattern+1 );
 	} else
-		return FALSE;
+		return false;
     case '*':
 	if ( string[0] == '/' ) return shellexp( string, pattern+1 );
 	{
 		int ret = shellexp( string, pattern+1 );
-		if (ret == FALSE)
-			return string[0] != '\0' ? shellexp( string + 1, pattern ) : FALSE;
+		if (ret == false)
+			return string[0] != '\0' ? shellexp( string + 1, pattern ) : false;
 		else
 			return ret;
 	}
     case '[': 
-	if ( string[0] == '\0' ) return FALSE;
+	if ( string[0] == '\0' ) return false;
 	{
-	    int nott = FALSE;
-	    int okay = FALSE;
+	    int nott = false;
+	    int okay = false;
 	    pattern++;
 	    if ( pattern[0] == '!' || pattern[0] == '^' ) {
-		nott = TRUE;
+		nott = true;
 		pattern++;
 	    }
 
 	    if ( pattern[0] == ']' ) {
-		if ( string[0] == ']' ) { okay = TRUE; }
+		if ( string[0] == ']' ) { okay = true; }
 		pattern++;
 	    }
 
 	    while( pattern[0] != ']' && pattern[0] != '\0' ) {
 		if ( pattern[0] == string[0] ) {
-		    okay = TRUE;
+		    okay = true;
 		} else if ( pattern[1] == '-' && pattern[2] != ']' ) {
 		    if ( pattern[0] <= string[0] && string[0] <= pattern[2] ) {
-			okay = TRUE;
+			okay = true;
 		    }
 		    pattern += 2;
 		}
@@ -83,13 +81,13 @@ int shellexp( char* string, char* pattern ) {
 	    }
 
 	    if (! (nott ? !okay : okay))
-	    	return FALSE;
+		return false;
 	    else
 	    	return shellexp( string + 1, pattern + 1 );
 	}
     default:
     	if (pattern[0] != string[0])
-		return FALSE;
+		return false;
 	else
 		return shellexp( string + 1, pattern + 1 );
     }


### PR DESCRIPTION
This includes various build system fixes and improvements that I noticed when fixing the project to work against latest dpkg git HEAD, as that includes a hard dependency on libmd, which the current build system here would miss and fail to link.

The shellexp.c could perhaps instead be converted to C++, I could do that if you prefer, I left it as is, as I assumed there was some reason to keep it that way.